### PR TITLE
Fix build on cross compilation environment  v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(MSVC)
 	endif()
 elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
 	# Update if necessary
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -Wno-reorder -pedantic ")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -Wno-reorder -pedantic -std=c++11")
 endif()
 
 include(VoleHelperMacros)

--- a/gui/controller/controller.h
+++ b/gui/controller/controller.h
@@ -9,7 +9,9 @@
 
 #include <QObject>
 #include <QMap>
+#ifndef Q_MOC_RUN
 #include <boost/thread.hpp>
+#endif
 
 // forward declarations
 


### PR DESCRIPTION
Changelog v2

Replace :

-std=c++1y

with

-std=c++11
