### PR TITLE
VoleFindPackages: Fix OpenGL cmake build

### DIFF
--- a/cmake/VoleFindPackages.cmake
+++ b/cmake/VoleFindPackages.cmake
@@ -47,8 +47,8 @@ vole_check_package(OPENGL
 	"OpenGL"
 	"Please check your OpenGL installation."
 	OpenGL_FOUND
-	"${OpenGL_INCLUDE_DIR}"
-	"${OpenGL_LIBRARIES}"
+	"${OPENGL_INCLUDE_DIR}"
+	"${OPENGL_LIBRARIES}"
 )
 
 # GLEW


### PR DESCRIPTION
FindOpenGL.cmake names the LIBRARY variable in capital letters.
https://cmake.org/gitweb?p=cmake.git;a=blob;f=Modules/FindOpenGL.cmake

Without this fix http://errors.yoctoproject.org/Errors/Details/21026/
